### PR TITLE
Filter other uses of ".host" in vcl script

### DIFF
--- a/dnscheck.sh
+++ b/dnscheck.sh
@@ -7,7 +7,7 @@ done
 
 get_backends()
 {
-  BACKEND_LIST=$(varnishadm vcl.show $(varnishadm vcl.list | grep active | awk '{print $4}') | egrep '^[ \t]+\.host[ \t]*=' | cut -d '"' -f 2)
+  BACKEND_LIST=$(varnishadm vcl.show $(varnishadm vcl.list | grep active | awk '{print $4}') | egrep '^[ \t]+\.host[ \t]*=' | grep -v nodnscheck | cut -d '"' -f 2)
   > /tmp/backend.list
   for backend in ${BACKEND_LIST}; do
 

--- a/dnscheck.sh
+++ b/dnscheck.sh
@@ -7,7 +7,7 @@ done
 
 get_backends()
 {
-  BACKEND_LIST=$(varnishadm vcl.show $(varnishadm vcl.list | grep active | awk '{print $4}') | egrep '^[ \t]+\.host[ \t]*=' | grep -v nodnscheck | cut -d '"' -f 2)
+  BACKEND_LIST=$(varnishadm vcl.show $(varnishadm vcl.list | grep active | awk '{print $4}') | egrep '^[ \t]+\.host[ \t]*=' | grep -v nodnscheck | cut -d '"' -f 2 | sort | uniq )
   > /tmp/backend.list
   for backend in ${BACKEND_LIST}; do
 

--- a/dnscheck.sh
+++ b/dnscheck.sh
@@ -7,7 +7,7 @@ done
 
 get_backends()
 {
-  BACKEND_LIST=$(varnishadm vcl.show $(varnishadm vcl.list | grep active | awk '{print $4}') | grep '.host' | cut -d '"' -f 2)
+  BACKEND_LIST=$(varnishadm vcl.show $(varnishadm vcl.list | grep active | awk '{print $4}') | egrep '^[ \t]+\.host[ \t]*=' | cut -d '"' -f 2)
   > /tmp/backend.list
   for backend in ${BACKEND_LIST}; do
 


### PR DESCRIPTION
You could have something like  set req.http.host = regsub(req.http.host, "\.$", ""); in your script that makes dnscheck.sh to fail.